### PR TITLE
fix: sync upstream patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+accountsservice (23.13.9-6deepin2) unstable; urgency=medium
+
+  * Synced upstream patch so that unit tests can be finished since
+    `assertequals` was replaced by `assertequal` in unittest module.
+
+ -- zhoushicheng <zhoushicheng@uniontech.com>  Tue, 12 Nov 2024 09:58:49 +0800
+
 accountsservice (23.13.9-6deepin1) unstable; urgency=medium
 
   * generate-version.sh: Do not guess version from git or tarball.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,5 @@ git_default_gdm.patch
 0002-create-and-manage-groups-like-on-a-debian-system.patch
 no-check-format.patch
 assume-version-from-d-changelog.patch
+tests-s-assertEquals-assertEqual.patch
+

--- a/debian/patches/tests-s-assertEquals-assertEqual.patch
+++ b/debian/patches/tests-s-assertEquals-assertEqual.patch
@@ -1,0 +1,44 @@
+From: Ray Strode <rstrode@redhat.com>
+Date: Thu, 28 Sep 2023 09:29:07 -0400
+Subject: tests: s/assertEquals/assertEqual/
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+CI is currently failing with:
+
+Traceback (most recent call last):
+  File "/home/user/accountsservice/_build/../tests/test-libaccountsservice.py", line 118, in test_multiple_inflight_get_user_by_id_calls
+    self.assertEquals(user.get_user_name(), 'pizza')
+    ^^^^^^^^^^^^^^^^^
+AttributeError: 'TestAccountsServicePreExistingUser' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?
+
+I have no idea if assertEquals was dropped, or if CI has been failing
+all this time or what.
+
+This commit makes the suggested change.
+
+[assertEquals was dropped in Python 3.12, as documented in
+https://docs.python.org/3/whatsnew/3.12.html#unittest-testcase-removed-aliases-smvc]
+
+Origin: upstream, 23.13.10, commit:ad0365b77b583da06bcd1e8da4c1bed74129895a
+Bug-Debian: https://bugs.debian.org/1074657
+---
+ tests/test-libaccountsservice.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/test-libaccountsservice.py b/tests/test-libaccountsservice.py
+index 723ab51..69b9083 100644
+--- a/tests/test-libaccountsservice.py
++++ b/tests/test-libaccountsservice.py
+@@ -115,8 +115,8 @@ class TestAccountsServicePreExistingUser(AccountsServiceTestBase):
+             self.assertTrue(user_objects[instance].is_loaded())
+ 
+         for user in user_objects:
+-            self.assertEquals(user.get_user_name(), 'pizza')
+-            self.assertEquals(user.get_uid(), 2001)
++            self.assertEqual(user.get_user_name(), 'pizza')
++            self.assertEqual(user.get_uid(), 2001)
+ 
+ @unittest.skipUnless(have_accounts_service,
+                      'AccountsService gi introspection not available')


### PR DESCRIPTION
synced upstream patch to fix assertequals deprecated method in python 3.12

Log: patch python sync